### PR TITLE
rebar.config: Fix deps syntax

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,6 @@
 	    {lager_extra_sinks, [netlink]}]}.
 
 {deps, [
-	{lager, ".*", {git, "git://github.com/basho/lager", {tag, "3.2.1"}}},
-	{gen_socket, ".*", {git, "git://github.com/travelping/gen_socket", "master"}}
+	{lager, ".*", {git, "https://github.com/basho/lager", {tag, "3.2.1"}}},
+	{gen_socket, ".*", {git, "https://github.com/travelping/gen_socket", {branch, "master"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,6 @@
 	    {lager_extra_sinks, [netlink]}]}.
 
 {deps, [
-	{lager, ".*", {git, "https://github.com/basho/lager", {tag, "3.2.1"}}},
+	{lager, ".*", {git, "https://github.com/erlang-lager/lager", {tag, "3.9.2"}}},
 	{gen_socket, ".*", {git, "https://github.com/travelping/gen_socket", {branch, "master"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,5 @@
 
 {deps, [
 	{lager, ".*", {git, "https://github.com/erlang-lager/lager", {tag, "3.9.2"}}},
-	{gen_socket, ".*", {git, "https://github.com/travelping/gen_socket", {branch, "master"}}}
+	{gen_socket, ".*", {git, "https://github.com/osmocom/gen_socket", {branch, "osmocom/master"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,5 @@
 
 {deps, [
 	{lager, ".*", {git, "https://github.com/erlang-lager/lager", {tag, "3.9.2"}}},
-	{gen_socket, ".*", {git, "https://github.com/osmocom/gen_socket", {branch, "osmocom/master"}}}
+	{gen_socket, ".*", {git, "https://github.com/osmocom/gen_socket", {branch, "pespin/master"}}}
 ]}.

--- a/src/netlink.erl
+++ b/src/netlink.erl
@@ -845,7 +845,7 @@ nl_dec_payload(_Type, done, << Length:32/native-integer >>) ->
 	Length;
 
 %% Error
-nl_dec_payload(_Type, error, <<Error:32, Msg/binary>>) ->
+nl_dec_payload(_Type, error, <<Error:32/native-signed-integer, Msg/binary>>) ->
     {Error, Msg};
 
 nl_dec_payload(ctnetlink, _MsgType, << Family:8, Version:8, ResId:16/native-integer, Data/binary >>) ->

--- a/src/netlink.erl
+++ b/src/netlink.erl
@@ -974,7 +974,7 @@ nl_ct_dec(_Protocol, << >>, Acc) ->
     lists:reverse(Acc).
 
 is_rt_dump(Type, Flags) ->
-    (Type band 3) =:= 2 andalso Flags band ?NLM_F_DUMP =/= 0.
+    (Type band 3) =:= 2 andalso Flags band ?NLM_F_DUMP =:= ?NLM_F_DUMP.
 
 -spec nl_rt_dec(binary()) -> [{'error',_} | #rtnetlink{}].
 nl_rt_dec(Msg) ->

--- a/src/netlink_decoder_gen.hrl
+++ b/src/netlink_decoder_gen.hrl
@@ -2660,6 +2660,9 @@ decode_linkinfo_gtp(_Family, 2, Value) ->
 decode_linkinfo_gtp(_Family, 3, Value) ->
     {hashsize, decode_huint32(Value)};
 
+decode_linkinfo_gtp(_Family, 4, Value) ->
+    {role, decode_huint32(Value)};
+
 decode_linkinfo_gtp(_Family, Id, Value) ->
     {Id, Value}.
 
@@ -5373,6 +5376,9 @@ encode_linkinfo_gtp(_Family, {fd1, Value}) ->
 
 encode_linkinfo_gtp(_Family, {hashsize, Value}) ->
     encode_huint32(3, Value);
+
+encode_linkinfo_gtp(_Family, {role, Value}) ->
+    encode_huint32(4, Value);
 
 encode_linkinfo_gtp(_Family, {Type, Value})
   when is_integer(Type), is_binary(Value) ->


### PR DESCRIPTION
* Fix git:// protocol not available anymore on github.
* Fix following warning from rebar3: "WARNING: It is recommended to use {branch, Name}, {tag, Tag} or {ref, Ref}, otherwise updating the dep may not work as expected."