### PR TITLE
netlink.erl: Fix is_rt_dump

### DIFF
--- a/src/netlink.erl
+++ b/src/netlink.erl
@@ -974,7 +974,7 @@ nl_ct_dec(_Protocol, << >>, Acc) ->
     lists:reverse(Acc).
 
 is_rt_dump(Type, Flags) ->
-    (Type band 3) =:= 2 andalso Flags band ?NLM_F_DUMP =/= 0.
+    (Type band 3) =:= 2 andalso Flags band ?NLM_F_DUMP =:= ?NLM_F_DUMP.
 
 -spec nl_rt_dec(binary()) -> [{'error',_} | #rtnetlink{}].
 nl_rt_dec(Msg) ->


### PR DESCRIPTION
https://kernel.org/doc/html/next/userspace-api/netlink/intro.html: """
For GET - NLM_F_ROOT and NLM_F_MATCH are combined into NLM_F_DUMP, and not used separately. NLM_F_ATOMIC is never used. """

This fixes nl_rt_dec() incorrectly entering the is_rt_dump() path when a response for create interface is received, because it has NLM_F_ROOT set but not NLM_F_MATCH, and hence before this patch it would make is_rtp_dump() incorrectly return true.